### PR TITLE
retrieve and send image in response for a single meik

### DIFF
--- a/backend/src/main/java/edu/brown/cs/student/main/server/responses/MeikDataResponse.java
+++ b/backend/src/main/java/edu/brown/cs/student/main/server/responses/MeikDataResponse.java
@@ -4,7 +4,7 @@ import com.squareup.moshi.Moshi;
 
 import java.util.Map;
 
-public record MeikDataResponse(String meikID, Map<String,Object> data,
+public record MeikDataResponse(String meikID, Map<String,Object> data,String image,
                                String message) {
 
 

--- a/backend/src/main/java/edu/brown/cs/student/main/utils/FirebaseStorageService.java
+++ b/backend/src/main/java/edu/brown/cs/student/main/utils/FirebaseStorageService.java
@@ -1,0 +1,51 @@
+package edu.brown.cs.student.main.utils;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.FileInputStream;
+
+public class FirebaseStorageService {
+
+  private final Storage storage;
+  private final String bucketName;
+
+  public FirebaseStorageService() {
+    try{
+      this.storage = StorageOptions.newBuilder()
+          .setCredentials(GoogleCredentials.fromStream(new FileInputStream("src/main/resources/meikdatabase-firebase-adminsdk-5r9bn-be1c95c791.json")))
+          .build()
+          .getService();
+      this.bucketName = "meikdatabase.appspot.com";
+    }catch(Exception e){
+      e.printStackTrace();
+      System.out.println("Error in FirebaseStorageService");
+      throw new RuntimeException("Error in FirebaseStorageService");
+    };
+
+  }
+
+  public byte[] getImageBytes( String imagePath) {
+    try{
+      System.out.println("imagePath: " + imagePath);
+      BlobId blobId = BlobId.of(this.bucketName, imagePath);
+      System.out.println("blobId: " + blobId);
+      Blob blob = storage.get(blobId);
+      // Check if the blob exists
+      if (blob != null) {
+        return blob.getContent();
+      } else {
+        throw new Exception("Blob does not exist");
+      }
+
+    }catch (Exception e) {
+      e.printStackTrace();
+      System.out.println("Error in getImageBytes");
+      return null;
+    }
+
+  }
+}
+


### PR DESCRIPTION
a meik image is now included in the response as a base64 encoded string. The response from the getMeikById endpoint has the following structure.

```bash
{
    meikId: "",
    data: {result:"success", user: {....user info....}},
    image: "base64 encoded string",
}
```

I didn't put the image into the user json of the response because it makes the response extremely hard to read.

Once frontend has successfully displayed an image we should comment out the image logic until caching has been implemented.